### PR TITLE
Fixes Content Size issue with a lot of tabs

### DIFF
--- a/CKViewPager/CKViewPager/ViewPagerController.m
+++ b/CKViewPager/CKViewPager/ViewPagerController.m
@@ -401,7 +401,7 @@ static const BOOL kFixLatterTabsPositions = NO;
     frame.size.width = self.tabWidth;
     tabView.frame = frame;
 
-    if (i < self.tabCount - 1) {
+    if (i < self.tabCount) {
       contentSizeWidth += CGRectGetWidth(tabView.frame) + self.padding;
     }
   }


### PR DESCRIPTION
When you have 10+ tabs ContentSize is not created appropriately. Content Size will be one tab less than it should. Fixed if statement to cycle through all items in items array
